### PR TITLE
Fixes build.gradle issue that prevents the Mod from compiling

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ buildscript {
 	}
 	
 	dependencies {
-		classpath 'net.minecraftforge.gradle:ForgeGradle:2.2-SNAPSHOT'
+		classpath 'net.minecraftforge.gradle:ForgeGradle:2.1-SNAPSHOT'
 		classpath 'org.ajoberstar:gradle-git:1.6.0'
 		classpath 'com.github.jengelman.gradle.plugins:shadow:1.2.4'
 	}


### PR DESCRIPTION
ForgeGradle 2.2 is only compatible to Minecraft 1.9 and higher, so in order to compile a Minecraft 1.8(.9) mod, an older version must be used.